### PR TITLE
Fix installation instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Simple validator of package SBoM
 # Installation
 
 ```
-git https://github.com/hesa/spdx-validator.git
+git clone https://github.com/hesa/spdx-validator.git
 cd spdx-validator
 pip install .
 ```


### PR DESCRIPTION
The word "clone" was missing in "git clone https://github.com/hesa/spdx-validator.git"

Signed-off-by: Marc-Etienne Vargenau <marc-etienne.vargenau@nokia.com>